### PR TITLE
Add Component Owners to Strimzi

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,11 +22,10 @@ After 6 months a maintainer will be given "Admin" access to the Strimzi reposito
 ### Component owners
 
 The component owners are responsible for development of a specific subproject or component within Strimzi.
-Such components might be represented by by a separate GitHub repository within the Strimzi organization (e.g. `strimzi-kafka-bridge`) or by a subdirectory in a GitHub repository (e.g. `./documentation/` in `strimzi-kafka-operator`).
+Such components might be represented by a separate GitHub repository within the Strimzi organization (e.g. `strimzi-kafka-bridge`) or by a subdirectory in a GitHub repository (e.g. `./documentation/` in `strimzi-kafka-operator`).
 The components owners are identified in the [`COMPONENT-OWNERS`](COMPONENT-OWNERS) file in this repository which also includes the component for which they are responsible.
-Additionally, each of the components will have `OWNERS` file in its root listing the owners.
 
-By definition, every maintainer is also owner for all components and does not have to be mentioned in the `OWNERS` list.
+By definition, every maintainer is also an owner for all components and does not have to be mentioned in the `OWNERS` list.
 
 #### Changes in component ownership
 
@@ -36,6 +35,7 @@ Component owners can be removed by a ⅔ majority maintainers vote.
 #### Github Project Administration
 
 Owners of components which have their own GitHub repository will get "Write" rights for given GitHub repository and will be able to merge approved PRs.
+Owners will not get "Admin" rights on any Strimzi GitHub repositories.
 
 ## Voting
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,9 +21,9 @@ After 6 months a maintainer will be given "Admin" access to the Strimzi reposito
 
 ### Component owners
 
-The component owners are responsible for development of a specific subproject or components within Strimzi.
+The component owners are responsible for development of a specific subproject or component within Strimzi.
 Such components might be represented by by a separate GitHub repository within the Strimzi organization (e.g. `strimzi-kafka-bridge`) or by a subdirectory in a GitHub repository (e.g. `./documentation/` in `strimzi-kafka-operator`).
-The components owners are identified in the [`COMPOENENT-OWNERS`](COMPONENT-OWNERS) file in this repository which also includes the component for which they are responsible.
+The components owners are identified in the [`COMPONENT-OWNERS`](COMPONENT-OWNERS) file in this repository which also includes the component for which they are responsible.
 Additionally, each of the components will have `OWNERS` file in its root listing the owners.
 
 By definition, every maintainer is also owner for all components and does not have to be mentioned in the `OWNERS` list.
@@ -35,7 +35,7 @@ Component owners can be removed by a ⅔ majority maintainers vote.
 
 #### Github Project Administration
 
-Owners of components which have their own GitHub repository will get commit rights for given GitHub repository.
+Owners of components which have their own GitHub repository will get "Write" rights for given GitHub repository and will be able to merge approved PRs.
 
 ## Voting
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,37 +1,70 @@
 # Strimzi Governance
 
 This document defines project governance for the Strimzi project.
+
+## Project Roles
+
+### Maintainers
+
+The maintainers are responsible for the overall development of the whole Strimzi project and all its components.
 The maintainers are identified in the [`MAINTAINERS`](MAINTAINERS) file. 
+
+#### Changes in Maintainership
+
+New maintainers are proposed by an existing maintainer and are elected by a ⅔ majority maintainers vote.
+Maintainers can be removed by a ⅔ majority maintainers vote.
+
+#### Github Project Administration
+
+Maintainers will be added to the collaborators list of the Strimzi repository with "Write" access.
+After 6 months a maintainer will be given "Admin" access to the Strimzi repository.
+
+### Component owners
+
+The component owners are responsible for development of a specific subproject or components within Strimzi.
+Such components might be represented by by a separate GitHub repository within the Strimzi organization (e.g. `strimzi-kafka-bridge`) or by a subdirectory in a GitHub repository (e.g. `./documentation/` in `strimzi-kafka-operator`).
+The components owners are identified in the [`COMPOENENT-OWNERS`](COMPONENT-OWNERS) file in this repository which also includes the component for which they are responsible.
+Additionally, each of the components will have `OWNERS` file in its root listing the owners.
+
+By definition, every maintainer is also owner for all components and does not have to be mentioned in the `OWNERS` list.
+
+#### Changes in component ownership
+
+New component owners can be proposed by any maintainer and are elected by a ⅔ majority maintainers vote.
+Component owners can be removed by a ⅔ majority maintainers vote.
+
+#### Github Project Administration
+
+Owners of components which have their own GitHub repository will get commit rights for given GitHub repository.
 
 ## Voting
 
-The Strimzi project employs voting to ensure no single member can dominate the project. Any maintainer may cast a vote.
+The Strimzi project employs voting to ensure no single member can dominate the project.
 
-For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR.
-Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+For formal votes, a specific statement of what is being voted on should be added to the relevant GitHub issue or PR.
+Voters should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
 
-## Changes in Maintainership
+### Approving PRs
 
-New maintainers are proposed by an existing maintainer and are elected by a ⅔ majority vote.
+PRs may be merged after receiving at least two positive maintainer votes.
+Voting for PRs can be done using a comment in the PR or by approving (or requesting changes) the PR.
+If the PR author is a maintainer, this counts as a vote.
 
-Maintainers can be removed by a ⅔ majority vote.
+PRs which affect only a single component can be approved by at least one positive maintainer vote and one positive vote from an owner of given component.
+If the PR author is a maintainer or an owner of given component, this counts as a vote.
 
-## Approving PRs
+### Proposals
 
-PRs may be merged after receiving at least two positive votes. If the PR author is a maintainer, this counts as a vote.
+Proposals can be opened against the [proposals repository](https://github.com/strimzi/proposals).
+Proposals should cover any changes to the Strimzi project which might significantly impact its users or the project direction.
+Proposals are approved by a ⅔ majority maintainers vote.
 
-## Github Project Administration
+### Changes in Governance
 
-Maintainers will be added to the collaborators list of the Strimzi repository with "Write" access.
+All changes in Governance require a ⅔ majority maintainers vote.
 
-After 6 months a maintainer will be given "Admin" access to the Strimzi repository.
+### Other Changes
 
-## Changes in Governance
-
-All changes in Governance require a ⅔ majority vote.
-
-## Other Changes
-
-Unless specified above, all other changes to the project require a ⅔ majority vote.
-Additionally, any maintainer may request that any change require a ⅔ majority vote.
+Unless specified above, all other changes to the project require a ⅔ majority maintainers vote.
+Additionally, any maintainer may request that any change require a ⅔ majority maintainers vote.
 


### PR DESCRIPTION
Strimzi governance currently recognises only maintainers - group of people who have control over the whole project. As Strimzi is growing into more different areas such as UI or OAuth, the current review process is increasingly challenging. We need to make sure that:
* PRs are reviewed in time
* The right people with the right knowledge are reviewing the PRs

To achieve that, I propose to add concept of _component owners_. Component owners will be responsible for individual sub-projects. E.g. UI, OAuth library or docs. That should help to ensure that more people have the _approve bit_ for PRs and that the people who actually understand the PR get to review and approve it while also decreasing the number of reviews the maintainers have to deal with. This concept is also suitable for new components where the people working on them might get immediately more responsibilities. Component owners can of course over time become regular maintainers as well.

This PR is a governance change and requires ⅔ majority vote. If this PR is approved, the first component owners can be proposed on the maintainer mailing list.