### PR TITLE
Add Security Policy document with details about reporting vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the governance documents for the Strimzi project:
 * [List of Maintainers](./MAINTAINERS)
 * [Code of Conduct](./CODE_OF_CONDUCT.md)
 * [License](./LICENSE)
+* [Security Policy](./SECURITY.md)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security is important for us. 
+Security vulnerabilities or suspected security vulnerabilities should be reported to Strimzi maintainers privately, to minimize attacks against current users of Strimzi before they are fixed. 
+Reported vulnerabilities will be investigated and patched on the next patch (or minor) release as soon as possible.
+
+**IMPORTANT: Please do not file public issues on GitHub for security vulnerabilities**
+
+To report a vulnerability or a security-related issue, please email the private mailing list [cncf-strimzi-maintainers@lists.cncf.io](cncf-strimzi-maintainers@lists.cncf.io) with the details of the vulnerability.
+Do not report non-security-impacting issues through this channel.
+Use GitHub issues instead.


### PR DESCRIPTION
This PR adds Security Policy in the `SECURITY.md` file. Once added, this policy should be linked from the other repositories to make it easy to find for users and report security issues privately.