### PR TITLE
Add component owners for the new test-clients repository

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -21,3 +21,8 @@ Matthew Chirgwin, IBM <chirmatt@uk.ibm.com> (@matthew-chirgwin)
 Chris Giblin, IBM <cgi@zurich.ibm.com> (@chris-giblin)
 Sean Rooney, IBM <sro@zurich.ibm.com> (@SeanRooooney)
 Pascal Vetsch, IBM <vep@zurich.ibm.com> (@zrlvep)
+
+# https://github.com/strimzi/test-clients
+
+Maroš Orsák, Red Hat <xorsak02@stud.fit.vutbr.cz> (@see-quick)
+Lukáš Král, Red Hat <lukywill16@gmail.com> (@im-konge)


### PR DESCRIPTION
The [Strimzi Proposal 21](https://github.com/strimzi/proposals/blob/main/021-special-repository-for-st-clients-based-on-example-clients.md) approved the creation of new repository [test-clients](https://github.com/strimzi/test-clients) and approved that the current component owners of System Tests should be also the initial component of the test-clients repository. This PR adds them to the list of component owners.