### PR TITLE
Propose change to voting about proposals

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,7 +57,18 @@ If the PR author is a maintainer or an owner of given component, this counts as 
 
 Proposals can be opened against the [proposals repository](https://github.com/strimzi/proposals).
 Proposals should cover any changes to the Strimzi project which might significantly impact its users or the project direction.
-Proposals are approved by a ⅔ majority maintainers vote.
+
+Voting about proposals is using +1, 0, -1 votes and their fractions, where:
+* +1 means "yes"
+* -1 means "no"
+* The numbers between +1 and -1 indicate how strongly you feel about the proposal
+
+_(Inspired by [Apache Software Foundation voting](https://www.apache.org/foundation/voting.html#expressing-votes-1-0-1-and-fractions))_
+
+Proposals are approved when they receive at least three +1 votes from maintainers and no -1 votes from maintainers.
++1 votes can be expressed by approving the proposal PR or in the comments.
+Other votes should be expressed in the comments.
+The proposal PR should be opened for at least 3 days to give everyone enough time to vote.
 
 ### Changes in Governance
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -65,9 +65,15 @@ Voting about proposals is using +1, 0, -1 votes and their fractions, where:
 
 _(Inspired by [Apache Software Foundation voting](https://www.apache.org/foundation/voting.html#expressing-votes-1-0-1-and-fractions))_
 
-Proposals are approved when they receive at least three +1 votes from maintainers and no -1 votes from maintainers.
+Votes from maintainers are binding and count towards the approval of the proposal.
+Non-maintainers are allowed and encouraged to vote as well.
+But their votes are non-binding and do not count towards approval or the proposal.
+
 +1 votes can be expressed by approving the proposal PR or in the comments.
 Other votes should be expressed in the comments.
+For example "+1 (binding)", or for a non-maintainer "+1 (non-binding)".
+
+Proposals are approved when they receive at least three +1 binding votes and no -1 binding votes.
 The proposal PR should be opened for at least 3 days to give everyone enough time to vote.
 
 ### Changes in Governance

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,7 +67,7 @@ _(Inspired by [Apache Software Foundation voting](https://www.apache.org/foundat
 
 Votes from maintainers are binding and count towards the approval of the proposal.
 Non-maintainers are allowed and encouraged to vote as well.
-But their votes are non-binding and do not count towards approval or the proposal.
+But their votes are non-binding and do not count towards approval of the proposal.
 
 +1 votes can be expressed by approving the proposal PR or in the comments.
 Other votes should be expressed in the comments.
@@ -84,4 +84,3 @@ All changes in Governance require a ⅔ majority maintainers vote.
 
 Unless specified above, all other changes to the project require a ⅔ majority maintainers vote.
 Additionally, any maintainer may request that any change require a ⅔ majority maintainers vote.
-


### PR DESCRIPTION
As discussed on the last Strimzi Community Call ... The current governance policy requires ⅔ majority in order to approve proposals. I believe that this is limiting further growth of the Strimzi community. As we add more maintainers, it will be harder and harder to approve the proposal because they will require more and more approvals. Also not everyone might have a strong opinion about each proposal to vote "yes" or "no" for it.

This PR suggests to change the voting process specifically for proposals. It suggests using +1, 0 and -1 votes and their fractions. This follows the voting used in the [Apache Software Foundation](https://www.apache.org/foundation/voting.html#expressing-votes-1-0-1-and-fractions). For a proposal to be approved, it would require three +1 votes and no -1 votes from Strimzi maintainers. The proposal should be always open for at least 3 days to give everyone a chance to comment / vote on it.

This gives maintainers better options to express their opinions by having more vote options (for example using +0 or -0 votes or fraction votes etc.) or by just not voting at all. This does not necessarily mean they are not interested in Strimzi anymore, but for example that they might be not interested in a particular area or it is not their area of expertise. It should ensure the proposal process can be smooth and reasonably fast even as we add more maintainers since it will not be needed to summon ⅔ of maintainers to approve the proposal. At the same time - if they have a very strong opinion - the -1 vote gives every maintainer a very strong tool to express their opinion.

This change does not impact any other votes such as about new maintainers or component owners, governance changes, etc.