### PR TITLE
Add Maroš as owner of the test container repositories

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -26,3 +26,11 @@ Pascal Vetsch, IBM <vep@zurich.ibm.com> (@zrlvep)
 
 Maroš Orsák, Red Hat <xorsak02@stud.fit.vutbr.cz> (@see-quick)
 Lukáš Král, Red Hat <lukywill16@gmail.com> (@im-konge)
+
+# https://github.com/strimzi/test-container
+
+Maroš Orsák, Red Hat <xorsak02@stud.fit.vutbr.cz> (@see-quick)
+
+# https://github.com/strimzi/test-container-images
+
+Maroš Orsák, Red Hat <xorsak02@stud.fit.vutbr.cz> (@see-quick)


### PR DESCRIPTION
This PR adds Maroš to the list of components owners for the https://github.com/strimzi/test-container and https://github.com/strimzi/test-container-images repositories as discussed on the maintainers mailing list.