### PR TITLE
Add Kate Stanley as a new Access Operator compoenent owner

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -15,3 +15,7 @@ Matthew Chirgwin, IBM <chirmatt@uk.ibm.com> (@matthew-chirgwin)
 Chris Giblin, IBM <cgi@zurich.ibm.com> (@chris-giblin)
 Sean Rooney, IBM <sro@zurich.ibm.com> (@SeanRooooney)
 Pascal Vetsch, IBM <vep@zurich.ibm.com> (@zrlvep)
+
+# https://github.com/strimzi/kafka-access-operator
+
+Kate Stanley, Red Hat <kstanley@redhat.com> (@katheris)


### PR DESCRIPTION
This Pr adds Kate Stanley as a component owner of the Access Operator (https://github.com/strimzi/kafka-access-operator).