### PR TITLE
Added Kyle Liberti as component owner of the MQTT - Kafka bridge repo

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -19,3 +19,7 @@ Pascal Vetsch, IBM <vep@zurich.ibm.com> (@zrlvep)
 # https://github.com/strimzi/kafka-access-operator
 
 Kate Stanley, Red Hat <kstanley@redhat.com> (@katheris)
+
+# https://github.com/strimzi/strimzi-mqtt-bridge
+
+Kyle Liberti, Red Hat <kliberti@redhat.com> (@kyguy)


### PR DESCRIPTION
As part of the LFX mentoring program, Kyle will be mentor (together with me) for the MQTT to Kafka bridge project.
I am adding him as component owner for the corresponding repository.