### PR TITLE
Add Mickael Maison as compoenent owner for the Metrics Reporter repository

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -23,3 +23,7 @@ Kate Stanley, Red Hat <kstanley@redhat.com> (@katheris)
 # https://github.com/strimzi/strimzi-mqtt-bridge
 
 Kyle Liberti, Red Hat <kliberti@redhat.com> (@kyguy)
+
+# https://github.com/strimzi/metrics-reporter
+
+Mickael Maison, Red Hat <mickael.maison@gmail.com> (@mimaison)


### PR DESCRIPTION
As Mickael wrote the proposal for the new MEtrics Reporter and wrote the PoC it will begin with, he should be also the component owner for this repository to be able to review contributions etc.