### PR TITLE
Add Federico Valeri as a new Topic Operator component owner

### DIFF
--- a/COMPONENT-OWNERS
+++ b/COMPONENT-OWNERS
@@ -2,6 +2,10 @@
 
 Daniel Laing, Red Hat <dlaing@redhat.com> (@laidan6000)
 
+# https://github.com/strimzi/strimzi-kafka-operator/topic-operator
+
+Federico Valeri, Red Hat <fedevaleri@gmail.com> (@fvaleri)
+
 # https://github.com/strimzi/strimzi-kafka-oauth
 
 Marko Strukelj, Red Hat <marko.strukelj@gmail.com> (@mstruk)


### PR DESCRIPTION
This PR adds Federico to the list of component owners as responsible for the Topic Operator.