### PR TITLE
Added emeritus maintainer status

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,6 +17,9 @@ New maintainers are proposed by an existing maintainer and are elected by a ⅔ 
 Maintainers can be removed by a ⅔ majority maintainers vote. 
 Maintainers removed by a vote are no longer considered maintainers or emeritus maintainers.
 Maintainers become emeritus maintainers either actively, by opening a PR against the MAINTAINERS file marking themselves as Emeritus, or implicitly after 6 months without any contribution to the project.
+
+### Emeritus maintainers
+
 An Emeritus maintainer has still access to all the Strimzi venues (e.g. Slack, Email, Community call, etc.).
 They can contribute to the project in any way which doesn't implies strong and long term commitment, as active maintainers do.
 The MAINTAINERS file may not always immediately reflect implicit emeritus status, as updates to mark maintainers as Emeritus are done asynchronously.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,12 +7,21 @@ This document defines project governance for the Strimzi project.
 ### Maintainers
 
 The maintainers are responsible for the overall development of the whole Strimzi project and all its components.
-The maintainers are identified in the [`MAINTAINERS`](MAINTAINERS) file. 
+Emeritus maintainers are former maintainers who are no longer actively involved in the project.
+In the rest of this document the term ‘maintainer’ will be assumed to mean ‘active maintainer’, unless qualified as ‘emeritus maintainer’.
+Both maintainers and emeritus maintainers are identified in the [`MAINTAINERS`](MAINTAINERS) file. 
 
 #### Changes in Maintainership
 
 New maintainers are proposed by an existing maintainer and are elected by a ⅔ majority maintainers vote.
-Maintainers can be removed by a ⅔ majority maintainers vote.
+Maintainers can be removed by a ⅔ majority maintainers vote. 
+Maintainers removed by a vote are no longer considered maintainers or emeritus maintainers.
+Maintainers become emeritus maintainers either actively, by opening a PR against the MAINTAINERS file marking themselves as Emeritus, or implicitly after 6 months without any contribution to the project.
+Updates to the MAINTAINERS to mark implicitly Emeritus maintainers happen asynchronously (i.e. the MAINTAINERS file is not normative about Emeritus status).
+An Emeritus maintainer reverts to being an active maintainer by contributing to the project again.
+For the purposes of Emeritus status contribution means:
+* Opening or reviewing a PR to any repo in the Strimzi organization.
+* Participating in discussions with the Strimzi community in any of its venues (e.g. Slack, Email, Community call, etc.) This includes non-public participation (e.g. on the maintainers-only email list)
 
 #### Github Project Administration
 
@@ -34,7 +43,7 @@ Component owners can be removed by a ⅔ majority maintainers vote.
 
 #### Github Project Administration
 
-Owners of components which have their own GitHub repository will get "Write" rights for given GitHub repository and will be able to merge approved PRs.
+Owners of components which have their own GitHub repository will get "Write" rights for that GitHub repository and will be able to merge approved PRs.
 Owners will not get "Admin" rights on any Strimzi GitHub repositories.
 
 ## Voting
@@ -50,8 +59,8 @@ PRs may be merged after receiving at least two positive maintainer votes.
 Voting for PRs can be done using a comment in the PR or by approving (or requesting changes) the PR.
 If the PR author is a maintainer, this counts as a vote.
 
-PRs which affect only a single component can be approved by at least one positive maintainer vote and one positive vote from an owner of given component.
-If the PR author is a maintainer or an owner of given component, this counts as a vote.
+PRs which affect only a single component can be approved by at least one positive maintainer vote and one positive vote from an owner of that component.
+If the PR author is a maintainer or an owner of that component, this counts as a vote.
 
 ### Proposals
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,11 +17,12 @@ New maintainers are proposed by an existing maintainer and are elected by a ⅔ 
 Maintainers can be removed by a ⅔ majority maintainers vote. 
 Maintainers removed by a vote are no longer considered maintainers or emeritus maintainers.
 Maintainers become emeritus maintainers either actively, by opening a PR against the MAINTAINERS file marking themselves as Emeritus, or implicitly after 6 months without any contribution to the project.
-Updates to the MAINTAINERS to mark implicitly Emeritus maintainers happen asynchronously (i.e. the MAINTAINERS file is not normative about Emeritus status).
-An Emeritus maintainer reverts to being an active maintainer by contributing to the project again.
-For the purposes of Emeritus status contribution means:
-* Opening or reviewing a PR to any repo in the Strimzi organization.
-* Participating in discussions with the Strimzi community in any of its venues (e.g. Slack, Email, Community call, etc.) This includes non-public participation (e.g. on the maintainers-only email list)
+An Emeritus maintainer has still access to all the Strimzi venues (e.g. Slack, Email, Community call, etc.).
+They can contribute to the project in any way which doesn't implies strong and long term commitment, as active maintainers do.
+The MAINTAINERS file may not always immediately reflect implicit emeritus status, as updates to mark maintainers as Emeritus are done asynchronously.
+An Emeritus maintainer reverts to being an active maintainer by starting a voting process.
+The voting process can also be started by an active maintainer instead.
+At least three +1 binding votes and no -1 binding votes, from active maintainers, are needed to accept the emeritus one to be considered active again.
 
 #### Github Project Administration
 


### PR DESCRIPTION
I would like to start a discussion about the possibility to introduce the "Emeritus" maintainer status within the Strimzi project.
With the definition of "Emeritus" maintainer, we are dealing with maintainers who were very active in the past, by helping the project, but haven't been contributing to it for long time in any form (i.e. development, documentation, PRs review, community help, advocacy, ...).
As pointed out by CNCF [here](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md#inactivity), inactivity is harmful to the project and the maintainers should show their committment and put effort to help the project and the community to grow.
Of course, it's possible that during the long lifetime of a project, some contributors are involved for some time, they deserve and get the maintainer status, continue to work on the project but then leave for any reasons. There is nothing bad about this, but the project should have some protection from what could be the consequences of that.
Mentioning a companion Strimzi project, but under a different foundation, even the Apache Kafka project has some definition of emeritus member as described [here](https://cwiki.apache.org/confluence/display/KAFKA/Bylaws).
While you can read more about what an "Emeritus" maintainer status through the PR, one example of how having this role helps, is about to simplify the voting process where we need the 2/3 of the maintainers (i.e. new maintainer election, or "other changes" as described in the current governance).
As an example, with the current 9 maintainers we would need 6 maintainers to approve which is almost the number of the active ones (7), which means unanimity. Shrinking the voting pool to the active maintainers would align better with the Strimzi governance.